### PR TITLE
Enabled redis-commander in docker-compose

### DIFF
--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -22,6 +22,14 @@ process. Therefore, there are corresponding `*-config-override.yaml` files that
 allow the developer to control the contents of these files. For an example, see
 the section below for "Publishing" under "base images".
 
+### Redis
+
+Examining keys in Redis can be an important part of working with portions of the code-base.
+redis-commander is configured as part of the developer docker-compose configuration 
+for PyCharm. To use it, simply execute the following from `gigantum-client/build/developer`:
+
+    docker-compose up redis-commander
+
 base images
 -----------
 

--- a/resources/client/redis.conf
+++ b/resources/client/redis.conf
@@ -66,7 +66,11 @@ tcp-backlog 511
 # Examples:
 #
 # bind 192.168.1.100 10.0.0.1
-bind 127.0.0.1
+# bind 127.0.0.1
+
+# By default, redis restricts listening to localhost, this disables that behavior
+# Access can be controlled via docker
+protected-mode no
 
 # Specify the path for the Unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen

--- a/resources/developer/docker_compose/pycharm-nix.yml
+++ b/resources/developer/docker_compose/pycharm-nix.yml
@@ -8,6 +8,8 @@ services:
       - "10000:10000"
       - "10001:10001"
       - "10002:10002"
+    expose:
+      - "6379"
     volumes:
       - {% WORKING_DIR %}:/mnt/gigantum:cached
       - /var/run/docker.sock:/var/run/docker.sock
@@ -17,7 +19,16 @@ services:
       - LOCAL_USER_ID={% USER_ID %}
       - HOST_WORK_DIR={% WORKING_DIR %}
       - PYCHARM-DEV=1
-    network_mode: "bridge"
+
+  redis-commander:
+    container_name: redis-commander
+    hostname: redis-commander
+    image: rediscommander/redis-commander:latest
+    restart: always
+    environment:
+      - REDIS_HOSTS=local:labmanager:6379
+    ports:
+      - "8081:8081"
 
 volumes:
   labmanager_share_vol:

--- a/resources/developer/docker_compose/pycharm-windows.yml
+++ b/resources/developer/docker_compose/pycharm-windows.yml
@@ -8,6 +8,8 @@ services:
       - "10000:10000"
       - "10001:10001"
       - "10002:10002"
+    expose:
+      - "6379"
     volumes:
       - {% WORKING_DIR %}:/mnt/gigantum:cached
       - //var/run/docker.sock:/var/run/docker.sock
@@ -17,7 +19,16 @@ services:
       - WINDOWS_HOST=1
       - HOST_WORK_DIR={% WORKING_DIR %}
       - PYCHARM-DEV=1
-    network_mode: "bridge"
+
+  redis-commander:
+    container_name: redis-commander
+    hostname: redis-commander
+    image: rediscommander/redis-commander:latest
+    restart: always
+    environment:
+      - REDIS_HOSTS=local:labmanager:6379
+    ports:
+      - "8081:8081"
 
 volumes:
   labmanager_share_vol:


### PR DESCRIPTION
See the developer notes changes for details on usage!

I implemented this because it was a PITA to inspect redis while debugging the rserver code (which makes heavier use of RQ than the jupyter code).

I changed the docker-compose networking so that it will no longer be on the default bridge (the default behavior of compose is to create an isolated bridge network for each file). The only thing that requires security review is enabling redis to listen on all incoming requests. So, now it's only locked down by configuration / docker / etc.

This PR also made me realize that updating our developer docker-compose is a PITA because there are 6 files. So, currently only implemented for the PyCharm templates.