### PR TITLE
Issue #446 - Untracked directory for intermediary files

### DIFF
--- a/packages/gtmapi/lmsrvlabbook/tests/snapshots/snap_test_labbook_queries.py
+++ b/packages/gtmapi/lmsrvlabbook/tests/snapshots/snap_test_labbook_queries.py
@@ -1039,6 +1039,14 @@ snapshots['TestLabBookServiceQueries.test_list_files_many 1'] = {
                                 'key': 'result.dat',
                                 'size': '3'
                             }
+                        },
+                        {
+                            'node': {
+                                'id': 'TGFiYm9va0ZpbGU6ZGVmYXVsdCZsYWJib29rMSZvdXRwdXQmdW50cmFja2VkLw==',
+                                'key': 'untracked/',
+                                'size': '0',
+                                'isDir': True
+                            }
                         }
                     ]
                 }
@@ -1098,6 +1106,7 @@ snapshots['TestLabBookServiceQueries.test_list_files_many 2'] = {
             'output': {
                 'files': {
                     'edges': [
+
                     ]
                 }
             }
@@ -1472,6 +1481,14 @@ snapshots['TestLabBookServiceQueries.test_list_all_files_many 1'] = {
                                 'isDir': True,
                                 'key': 'empty/',
                                 'size': '0'
+                            }
+                        },
+                        {
+                            'node': {
+                                'id': 'TGFiYm9va0ZpbGU6ZGVmYXVsdCZsYWJib29rMSZvdXRwdXQmdW50cmFja2VkLw==',
+                                'key': 'untracked/',
+                                'size': '0',
+                                'isDir': True
                             }
                         },
                         {

--- a/packages/gtmapi/lmsrvlabbook/tests/test_labbook_mutations.py
+++ b/packages/gtmapi/lmsrvlabbook/tests/test_labbook_mutations.py
@@ -21,15 +21,10 @@ import io
 import math
 import os
 import tempfile
-import datetime
 import pprint
-from zipfile import ZipFile
-from pkg_resources import resource_filename
-import getpass
 import json
 
 from gtmcore.fixtures import ENV_UNIT_TEST_REPO, ENV_UNIT_TEST_BASE, ENV_UNIT_TEST_REV
-from gtmcore.files import FileOperations
 
 from snapshottest import snapshot
 from lmsrvlabbook.tests.fixtures import fixture_working_dir_env_repo_scoped, fixture_working_dir
@@ -39,7 +34,6 @@ from graphene.test import Client
 from mock import patch
 from werkzeug.datastructures import FileStorage
 
-from gtmcore.configuration import Configuration
 from gtmcore.dispatcher.jobs import export_labbook_as_zip
 from gtmcore.files import FileOperations
 from gtmcore.fixtures import remote_labbook_repo, mock_config_file
@@ -233,6 +227,7 @@ class TestLabBookServiceMutations(object):
                      "component_id": ENV_UNIT_TEST_BASE, "repository": ENV_UNIT_TEST_REPO,
                      "revision": ENV_UNIT_TEST_REV}
         r = fixture_working_dir_env_repo_scoped[2].execute(query, variable_values=variables)
+        pprint.pprint(r)
         assert 'errors' not in r
         assert r['data']['createLabbook']['labbook']['input']['isUntracked'] is True
         assert r['data']['createLabbook']['labbook']['output']['isUntracked'] is True

--- a/packages/gtmapi/lmsrvlabbook/tests/test_labbook_mutations.py
+++ b/packages/gtmapi/lmsrvlabbook/tests/test_labbook_mutations.py
@@ -227,7 +227,6 @@ class TestLabBookServiceMutations(object):
                      "component_id": ENV_UNIT_TEST_BASE, "repository": ENV_UNIT_TEST_REPO,
                      "revision": ENV_UNIT_TEST_REV}
         r = fixture_working_dir_env_repo_scoped[2].execute(query, variable_values=variables)
-        pprint.pprint(r)
         assert 'errors' not in r
         assert r['data']['createLabbook']['labbook']['input']['isUntracked'] is True
         assert r['data']['createLabbook']['labbook']['output']['isUntracked'] is True

--- a/packages/gtmapi/lmsrvlabbook/tests/test_labbook_queries.py
+++ b/packages/gtmapi/lmsrvlabbook/tests/test_labbook_queries.py
@@ -715,7 +715,9 @@ class TestLabBookServiceQueries(object):
                       }
                     }
                     """
-        snapshot.assert_match(fixture_working_dir[2].execute(query))
+        r = fixture_working_dir[2].execute(query)
+        pprint.pprint(r)
+        snapshot.assert_match(r)
 
         # Just get the files in the sub-directory "js"
         query = """
@@ -761,7 +763,9 @@ class TestLabBookServiceQueries(object):
                   }
                 }
                 """
-        snapshot.assert_match(fixture_working_dir[2].execute(query))
+        r = fixture_working_dir[2].execute(query)
+        pprint.pprint(r)
+        snapshot.assert_match(r)
 
     def test_list_favorites(self, fixture_working_dir, snapshot):
         """Test listing labbook favorites"""
@@ -1131,7 +1135,9 @@ class TestLabBookServiceQueries(object):
                       }
                     }
                     """
-        snapshot.assert_match(fixture_working_dir[2].execute(query))
+        r = fixture_working_dir[2].execute(query)
+        pprint.pprint(r)
+        snapshot.assert_match(r)
 
     def test_get_activity_records_next_page(self, fixture_working_dir_env_repo_scoped, snapshot, fixture_test_file):
         """Test next page logic, which requires a labbook to be created properly with an activity"""

--- a/packages/gtmapi/lmsrvlabbook/tests/test_labbook_queries.py
+++ b/packages/gtmapi/lmsrvlabbook/tests/test_labbook_queries.py
@@ -17,8 +17,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import pytest
-
 import os
 import time
 from snapshottest import snapshot
@@ -29,7 +27,6 @@ from gtmcore.fixtures import ENV_UNIT_TEST_REPO, ENV_UNIT_TEST_BASE, ENV_UNIT_TE
 import datetime
 import pprint
 import aniso8601
-import graphene
 
 import gtmcore
 
@@ -716,7 +713,6 @@ class TestLabBookServiceQueries(object):
                     }
                     """
         r = fixture_working_dir[2].execute(query)
-        pprint.pprint(r)
         snapshot.assert_match(r)
 
         # Just get the files in the sub-directory "js"
@@ -764,7 +760,6 @@ class TestLabBookServiceQueries(object):
                 }
                 """
         r = fixture_working_dir[2].execute(query)
-        pprint.pprint(r)
         snapshot.assert_match(r)
 
     def test_list_favorites(self, fixture_working_dir, snapshot):
@@ -1136,7 +1131,6 @@ class TestLabBookServiceQueries(object):
                     }
                     """
         r = fixture_working_dir[2].execute(query)
-        pprint.pprint(r)
         snapshot.assert_match(r)
 
     def test_get_activity_records_next_page(self, fixture_working_dir_env_repo_scoped, snapshot, fixture_test_file):
@@ -1401,7 +1395,6 @@ class TestLabBookServiceQueries(object):
         """
         # Uses an invalid string
         r = fixture_working_dir[2].execute(query)
-        pprint.pprint(r)
         assert 'errors' in r
         snapshot.assert_match(r)
 

--- a/packages/gtmcore/gtmcore/files/files.py
+++ b/packages/gtmcore/gtmcore/files/files.py
@@ -107,7 +107,7 @@ class FileOperations(object):
                         f'{section}/*', f'!{section}/.gitkeep']
 
         if cls.is_set_untracked(labbook, section):
-            return
+            return labbook
 
         with open(os.path.join(labbook.root_dir, '.gitignore'), 'a') as gi_file:
             gi_file.write('\n'.join([''] + append_lines + ['']))

--- a/packages/gtmcore/gtmcore/files/files.py
+++ b/packages/gtmcore/gtmcore/files/files.py
@@ -83,6 +83,8 @@ class FileOperations(object):
         indexes for the files. Note that this must be set before uploading
         files to the given `section`.
 
+        Must be called at project creation!
+
         Args:
             labbook: Subject labbook
             section: Section to set untracked - one of code, input, or output.
@@ -105,8 +107,7 @@ class FileOperations(object):
                         f'{section}/*', f'!{section}/.gitkeep']
 
         if cls.is_set_untracked(labbook, section):
-            raise FileOperationsException(f'Section {section} already '
-                                          f'untracked in {str(labbook)}')
+            return
 
         with open(os.path.join(labbook.root_dir, '.gitignore'), 'a') as gi_file:
             gi_file.write('\n'.join([''] + append_lines + ['']))

--- a/packages/gtmcore/gtmcore/files/files.py
+++ b/packages/gtmcore/gtmcore/files/files.py
@@ -100,11 +100,6 @@ class FileOperations(object):
             raise FileOperationsException(f'Section {section} not found '
                                           f'in {str(labbook)}')
 
-        filelist = os.listdir(section_path)
-        if not(len(filelist) == 1 and filelist[0] == '.gitkeep'):
-            raise FileOperationsException(f'Files already exist in '
-                                          f'{str(labbook)} section {section}')
-
         append_lines = [f'# Ignore files for section {section} - '
                         f'fix to improve Git performance with large files',
                         f'{section}/*', f'!{section}/.gitkeep']

--- a/packages/gtmcore/gtmcore/files/tests/test_fileoperations.py
+++ b/packages/gtmcore/gtmcore/files/tests/test_fileoperations.py
@@ -62,50 +62,6 @@ class TestFileOps(object):
         for key in s.keys():
             assert not s[key]
 
-    def test_make_sure_cannot_set_when_files_already_exist_in_section(self, mock_labbook):
-        x, y, lb = mock_labbook
-
-        # 2 - Add a file to the input directory using the old-fashioned add file op.
-        with open('/tmp/unittestfile', 'wb') as f:
-            f.write("xxxxxxxxxxxxxxxč".encode('utf-8'))
-        r = FileOperations.put_file(lb, section="input", src_file=f.name, dst_path='')
-        assert os.path.isfile(os.path.join(lb.root_dir, 'input', 'unittestfile'))
-
-        with pytest.raises(FileOperationsException):
-            FileOperations.set_untracked(labbook=lb, section='input')
-
-        assert FileOperations.is_set_untracked(labbook=lb, section='input') is False
-
-    def test_make_sure_cannot_set_untracked_twice(self, mock_labbook):
-        x, y, lb = mock_labbook
-
-        hash_0 = lb.git.commit_hash
-        FileOperations.set_untracked(labbook=lb, section='input')
-
-        # 1 - Ensure there are no untracked changes after the set operation
-        s = lb.git.status()
-
-        for key in s.keys():
-            assert not s[key]
-
-        # 2 - Add a file to the input directory using the old-fashioned add file op.
-        hash_1 = lb.git.commit_hash
-        with open('/tmp/unittestfile', 'w') as f:
-            f.write('------------------------\n')
-        r = FileOperations.put_file(lb, section="input", src_file=f.name, dst_path='')
-        hash_2 = lb.git.commit_hash
-        assert os.path.isfile(os.path.join(lb.root_dir, 'input', 'unittestfile'))
-
-        # Cannot set this field twice.
-        with pytest.raises(FileOperationsException):
-            FileOperations.set_untracked(labbook=lb, section='input')
-        hash_3 = lb.git.commit_hash
-
-        assert hash_0 != hash_1
-        assert hash_1 == hash_2
-        assert hash_2 == hash_3
-        assert FileOperations.is_set_untracked(labbook=lb, section='input') is True
-
     def test_with_the_whole_suite_of_file_operations_on_an_UNTRACKED_labbook(self, mock_labbook):
         x, y, lb = mock_labbook
 

--- a/packages/gtmcore/gtmcore/labbook/gitignore.default
+++ b/packages/gtmcore/gtmcore/labbook/gitignore.default
@@ -2,6 +2,8 @@
 **/.DS_Store
 /**/.DS_Store
 
+# Make a directory for intermediary files that should NOT ever be tracked
+output/untracked
 
 # Ignore the checkout context file, because it should always get recreated when a repo moves or is checked out
 .gigantum/.checkout

--- a/packages/gtmcore/gtmcore/labbook/labbook.py
+++ b/packages/gtmcore/gtmcore/labbook/labbook.py
@@ -182,9 +182,11 @@ class LabBook(Repository):
         if not self.root_dir:
             raise ValueError("No root directory assigned to lab book. Failed to get root directory.")
 
-        untracked_dir = os.path.join(self.root_dir, 'output', 'untracked')
-        if not os.path.exists(untracked_dir):
-            os.makedirs(untracked_dir, exist_ok=True)
+        untracked_patterns = [l.strip() for l in open(os.path.join(self.root_dir, '.gitignore')).readlines()]
+        if 'output/untracked' in untracked_patterns:
+            untracked_dir = os.path.join(self.root_dir, 'output', 'untracked')
+            if not os.path.exists(untracked_dir):
+                os.makedirs(untracked_dir, exist_ok=True)
 
         with open(os.path.join(self.root_dir, ".gigantum", "labbook.yaml"), 'rt') as lbfile:
             self._data = yaml.safe_load(lbfile)

--- a/packages/gtmcore/gtmcore/labbook/labbook.py
+++ b/packages/gtmcore/gtmcore/labbook/labbook.py
@@ -182,6 +182,10 @@ class LabBook(Repository):
         if not self.root_dir:
             raise ValueError("No root directory assigned to lab book. Failed to get root directory.")
 
+        untracked_dir = os.path.join(self.root_dir, 'output', 'untracked')
+        if not os.path.exists(untracked_dir):
+            os.mkdir(untracked_dir, exist_ok=True)
+
         with open(os.path.join(self.root_dir, ".gigantum", "labbook.yaml"), 'rt') as lbfile:
             self._data = yaml.safe_load(lbfile)
 

--- a/packages/gtmcore/gtmcore/labbook/labbook.py
+++ b/packages/gtmcore/gtmcore/labbook/labbook.py
@@ -184,7 +184,7 @@ class LabBook(Repository):
 
         untracked_dir = os.path.join(self.root_dir, 'output', 'untracked')
         if not os.path.exists(untracked_dir):
-            os.mkdir(untracked_dir, exist_ok=True)
+            os.makedirs(untracked_dir, exist_ok=True)
 
         with open(os.path.join(self.root_dir, ".gigantum", "labbook.yaml"), 'rt') as lbfile:
             self._data = yaml.safe_load(lbfile)


### PR DESCRIPTION
## Pull Request for Issue #446 

**Describe changes introduced by this PR (Bugs fixed, features added, docs updated, etc.)**:

Creates a new directory in the `output` file section called `untracked`. While this directory should always exist, its contents are _never_ tracked. This is to help with intermediary data products.


**Please check if the PR fulfills these requirements**

  - PR is set to merge to integration
  - Commit message is descriptive
  - Tests have been added (for bug fixes/features)
  - Docs have been added/updated (for bug fixes/features)

**Exit Criteria**:

* [x] When syncing or sharing between users, the contents of `untracked` are never tracked.
* [x] Intermediary data products _are indeed_ retained during zip file export.
* [x] Old-style labbooks (before migration) do not have an untracked directory.

