### PR TITLE
Correct visibility will be used when publishing local linked datasets

### DIFF
--- a/ui/src/js/components/shared/header/branches/BranchMenu.js
+++ b/ui/src/js/components/shared/header/branches/BranchMenu.js
@@ -324,11 +324,12 @@ class BranchMenu extends Component {
   *  @param {Boolean} - pullOnly
   *  @param {Boolean} - allowSync
   *  @param {Boolean} - allowSyncPull
+  *  @param {Function} - passedSuccessCall
   *  handles syncing or publishing the project
   *  @return {}
   */
   @boundMethod
-  _handleSyncButton(pullOnly, allowSync, allowSyncPull) {
+  _handleSyncButton(pullOnly, allowSync, allowSyncPull, passedSuccessCall) {
     this.setState({ syncMenuVisible: false });
     if (allowSync || (pullOnly && allowSyncPull)) {
       if (!this.props.defaultRemote) {
@@ -383,6 +384,9 @@ class BranchMenu extends Component {
                 this.state.branchMutations.syncLabbook(data, (response, error) => {
                   if (error) {
                     data.failureCall(error);
+                  }
+                  if (passedSuccessCall) {
+                    passedSuccessCall();
                   }
                 });
               } else {

--- a/ui/src/js/components/shared/header/titleSection/TitleSection.js
+++ b/ui/src/js/components/shared/header/titleSection/TitleSection.js
@@ -28,6 +28,7 @@ export default class TitleSection extends Component {
           visibilityIconCSS = classNames({
             [`TitleSection__${visibility}`]: true,
             [`TitleSection__${visibility}--sticky`]: props.isSticky,
+            'Tooltip-data Tooltip-data--small': true,
           }),
           title = `${section.owner} / ${section.name}`;
     return (
@@ -36,7 +37,10 @@ export default class TitleSection extends Component {
         <div className="TitleSection__namespace">
           <div className="TitleSection__namespace-title">{title}</div>
           { ((visibility === 'private') || (visibility === 'public'))
-              && <div className={visibilityIconCSS} />
+              && <div
+                className={visibilityIconCSS}
+                data-tooltip={visibility}
+              />
           }
         </div>
 

--- a/ui/src/js/components/shared/modals/PublishDatasetsModal.js
+++ b/ui/src/js/components/shared/modals/PublishDatasetsModal.js
@@ -43,7 +43,7 @@ export default class PublishDatasetsModal extends Component {
   static getDerivedStateFromProps(nextProps, nextState) {
     const NewVisibilityStatus = Object.assign({}, nextState.visibilityStatus);
     nextProps.localDatasets.forEach(({ owner, name }) => {
-      if (!NewVisibilityStatus[`${owner}/${name}`]) {
+      if (NewVisibilityStatus[`${owner}/${name}`] === undefined) {
         NewVisibilityStatus[`${owner}/${name}`] = null;
       }
       if (nextProps.header === 'Sync') {
@@ -65,7 +65,7 @@ export default class PublishDatasetsModal extends Component {
   */
   _setPublic(name, isPublic) {
     const NewVisibilityStatus = Object.assign({}, this.state.visibilityStatus);
-    NewVisibilityStatus[name] = isPublic ? 'public' : 'private';
+    NewVisibilityStatus[name] = isPublic;
     this.setState({ visibilityStatus: NewVisibilityStatus });
   }
 
@@ -108,6 +108,13 @@ export default class PublishDatasetsModal extends Component {
                     self.props.toggleSyncModal();
                   }
                 }
+              };
+
+              const passedSuccessCall = () => {
+                const successProgress = Object.assign({}, this.state.progress);
+                successProgress.project = { step: 3 };
+                this.setState({ progress: successProgress });
+                setTimeout(() => this.props.toggleModal(false, true), 2000);
               };
 
               const successCall = () => {
@@ -200,7 +207,7 @@ export default class PublishDatasetsModal extends Component {
                                           },
                                         );
                                       } else {
-                                        this.props.handleSync(false, true, true);
+                                        this.props.handleSync(false, true, true, passedSuccessCall);
                                       }
                                     }
                                   }


### PR DESCRIPTION
## Pull Request for Issue #XXX

**Describe changes introduced by this PR (Bugs fixed, features added, docs updated, etc.)**:

- publish local linked datasets workflow was passing a string instead of a boolean to isPublic, causing all published datasets via the workflow to be public, now passes in the correct input
- fixed bug causing modal not to close