### PR TITLE
Expand docker version support when using GPUs

### DIFF
--- a/changelog/releases/v1.5.4/wsl2-gpu.yaml
+++ b/changelog/releases/v1.5.4/wsl2-gpu.yaml
@@ -1,0 +1,4 @@
+prLink: "https://github.com/gigantum/gigantum-client/pull/1837"
+changelog:
+  - type: NEW
+    description: Adds support for GPUs on WSL2 and hosts where nvidia-container-toolkit is installed instead of nvidia-docker2

--- a/packages/gtmcore/gtmcore/container/cuda.py
+++ b/packages/gtmcore/gtmcore/container/cuda.py
@@ -115,12 +115,12 @@ class GPUInventory:
         """
         client = self._get_redis_client()
         if not num_gpus:
-            num_gpus = self._num_gpus()
+            num_gpus = self.num_gpus()
         logger.info(f"{num_gpus} GPUs detected during initialization.")
         for idx in range(num_gpus):
             client.rpush(self.GPUS_AVAILABLE_KEY, idx)
 
-    def _num_gpus(self) -> int:
+    def num_gpus(self) -> int:
         """Get the number of GPUs available on the host via the env var `NVIDIA_NUM_GPUS`, which is set by the CLI
 
         Returns:

--- a/packages/gtmcore/gtmcore/container/local_container.py
+++ b/packages/gtmcore/gtmcore/container/local_container.py
@@ -173,7 +173,6 @@ class LocalProjectContainer(ContainerOperations):
             return True
 
     # Working with Containers
-
     def run_container(self, cmd: Optional[str] = None, image_name: Optional[str] = None, environment: List[str] = None,
                       volumes: Optional[Dict] = None, wait_for_output=False, container_name: Optional[str] = None,
                       **run_args) \
@@ -239,9 +238,17 @@ class LocalProjectContainer(ContainerOperations):
                 if volumes:
                     for v in volumes:
                         binds.append(f"{v}:{volumes[v]['bind']}:{volumes[v]['mode']}")
+
+                    if os.environ.get('NVIDIA_SMI_PATH'):
+                        binds.append(f"{os.environ.get('NVIDIA_SMI_PATH')}:/usr/local/bin/nvidia-smi:ro")
+
                     run_args['binds'] = binds
 
                 run_args['init'] = True
+
+                # TODO DMK - delete the runtime so you don't need nvidia docker....need to refactor this to be configurable.
+                del run_args['runtime']
+
                 create_kwargs = self._client.api.create_host_config(**run_args)
 
                 resp = self._client.api.create_container(image=image_name, detach=True, name=container_name,

--- a/packages/gtmcore/gtmcore/container/tests/test_cuda_gpu_inventory.py
+++ b/packages/gtmcore/gtmcore/container/tests/test_cuda_gpu_inventory.py
@@ -19,11 +19,11 @@ class TestGPUInventory(object):
     # THIS TEST ASSUMES YOU ARE NOT RUNNING ON A GPU MACHINE
     def test_num_gpus(self, gpu_inventory):
         # Test path where GPUs are not enabled
-        assert gpu_inventory._num_gpus() == 0
+        assert gpu_inventory.num_gpus() == 0
 
         # Test path where GPUs are enabled but an error occurs
         os.environ['NVIDIA_NUM_GPUS'] = "3"
-        assert gpu_inventory._num_gpus() == 3
+        assert gpu_inventory.num_gpus() == 3
 
     def test_init(self, gpu_inventory):
         client = redis.Redis(db=gpu_inventory.REDIS_DB, decode_responses=True)


### PR DESCRIPTION
**Describe changes introduced by this PR (Bugs fixed, features added, docs updated, etc.)**:
This PR adds support for switching between using the nvidia runtime and simply depending on the low-level API to use GPUs in Projects. This lets us run with GPUs on WSL2 in Windows and better handles different Docker and nvidia configurations.

**QA Test Steps and Exit Criteria**:
- [x] Launching on a single GPU machine
- [x] Launching on a multi GPU machine with reservations
- [x] Launching on a multi GPU machine without reservations
- [x] Launching on a non-GPU machine
- [x] Testing with an older version of docker (pre 1.40)

